### PR TITLE
fix: refactoring pad to use cds-layout attr

### DIFF
--- a/src/clr-core/styles/layout/_spacing.scss
+++ b/src/clr-core/styles/layout/_spacing.scss
@@ -2,73 +2,12 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
+@import './mixins/mixins';
+
 // why are we doing these in groups?
 // so that more explicit side declarations can override more general axis declarations
 // it's more verbose but allows customization through greater specificity
 // <div cds-layout="pad-sm pad-top-lg pad-bottom-none">...</div>
-
-@function getPadAttributeString($side: null, $size: 'none', $breakpoint: null) {
-  $formattedSide: '';
-  $formattedBreakpoint: '';
-
-  @if $side {
-    $formattedSide: #{'-' + $side};
-  }
-
-  @if $breakpoint {
-    $formattedBreakpoint: #{'@' + $breakpoint};
-  }
-
-  @return #{'pad' + $formattedSide + '-' + $size + $formattedBreakpoint};
-}
-
-@function getLayoutSpacingToken($size: null) {
-  @if $size == 'xs' {
-    @return $cds-token-layout-space-xs;
-  } @else if $size == 'sm' {
-    @return $cds-token-layout-space-sm;
-  } @else if $size == 'md' {
-    @return $cds-token-layout-space-md;
-  } @else if $size == 'lg' {
-    @return $cds-token-layout-space-md;
-  } @else if $size == 'xl' {
-    @return $cds-token-layout-space-md;
-  } @else {
-    @return 0;
-  }
-}
-
-@mixin cdsLayoutPadder($sides: null, $breakpoint: null) {
-  $tShirtSizes: 'none', 'xs', 'sm', 'md', 'lg', 'xl';
-
-  @each $size in $tShirtSizes {
-    $value: getLayoutSpacingToken($size);
-
-    @if $sides == null {
-      [cds-layout~=#{'"' + getPadAttributeString(null, $size, $breakpoint) + '"'}] {
-        padding: $value !important;
-      }
-    } @else {
-      @each $side in $sides {
-        @if $side == 'horizontal' {
-          [cds-layout~=#{'"' + getPadAttributeString($side, $size, $breakpoint) + '"'}] {
-            padding-left: $value !important;
-            padding-right: $value !important;
-          }
-        } @else if $side == 'vertical' {
-          [cds-layout~=#{'"' + getPadAttributeString($side, $size, $breakpoint) + '"'}] {
-            padding-top: $value !important;
-            padding-bottom: $value !important;
-          }
-        } @else {
-          [cds-layout~=#{'"' + getPadAttributeString($side, $size, $breakpoint) + '"'}] {
-            padding-#{$side}: $value !important;
-          }
-        }
-      }
-    }
-  }
-}
 
 // padding all around
 
@@ -103,9 +42,21 @@
   @include cdsLayoutPadder('top' 'right' 'bottom' 'left', 'lg');
 }
 
+// TODO: REMOVE ALL TESTER CODE!
+
+#tester {
+  @include cdsLayoutHorizontalGapper();
+  @include cdsLayoutVerticalGapper();
+}
+
 // responsive breakpoint – xl
 @media (min-width: $cds-token-layout-width-xl-static) {
   @include cdsLayoutPadder(null, 'xl');
   @include cdsLayoutPadder('horizontal' 'vertical', 'xl');
   @include cdsLayoutPadder('top' 'right' 'bottom' 'left', 'xl');
+
+  #tester {
+    @include cdsLayoutHorizontalGapper('xl');
+    @include cdsLayoutVerticalGapper('xl');
+  }
 }

--- a/src/clr-core/styles/layout/_spacing.scss
+++ b/src/clr-core/styles/layout/_spacing.scss
@@ -2,108 +2,110 @@
 // This software is released under MIT license.
 // The full license information can be found in LICENSE in the root directory of this project.
 
-// TODO: phase two needs specific sides and @ breakpoints
+// why are we doing these in groups?
+// so that more explicit side declarations can override more general axis declarations
+// it's more verbose but allows customization through greater specificity
+// <div cds-layout="pad-sm pad-top-lg pad-bottom-none">...</div>
 
-[cds-pad='none'],
-cds-layout[pad='none'] {
-  padding: 0 !important;
+@function getPadAttributeString($side: null, $size: 'none', $breakpoint: null) {
+  $formattedSide: '';
+  $formattedBreakpoint: '';
+
+  @if $side {
+    $formattedSide: #{'-' + $side};
+  }
+
+  @if $breakpoint {
+    $formattedBreakpoint: #{'@' + $breakpoint};
+  }
+
+  @return #{'pad' + $formattedSide + '-' + $size + $formattedBreakpoint};
 }
 
-[cds-pad='xs'],
-cds-layout[pad='xs'] {
-  padding: $cds-token-layout-space-xs !important;
+@function getLayoutSpacingToken($size: null) {
+  @if $size == 'xs' {
+    @return $cds-token-layout-space-xs;
+  } @else if $size == 'sm' {
+    @return $cds-token-layout-space-sm;
+  } @else if $size == 'md' {
+    @return $cds-token-layout-space-md;
+  } @else if $size == 'lg' {
+    @return $cds-token-layout-space-md;
+  } @else if $size == 'xl' {
+    @return $cds-token-layout-space-md;
+  } @else {
+    @return 0;
+  }
 }
 
-[cds-pad='sm'],
-cds-layout[pad='sm'] {
-  padding: $cds-token-layout-space-sm !important;
+@mixin cdsLayoutPadder($sides: null, $breakpoint: null) {
+  $tShirtSizes: 'none', 'xs', 'sm', 'md', 'lg', 'xl';
+
+  @each $size in $tShirtSizes {
+    $value: getLayoutSpacingToken($size);
+
+    @if $sides == null {
+      [cds-layout~=#{'"' + getPadAttributeString(null, $size, $breakpoint) + '"'}] {
+        padding: $value !important;
+      }
+    } @else {
+      @each $side in $sides {
+        @if $side == 'horizontal' {
+          [cds-layout~=#{'"' + getPadAttributeString($side, $size, $breakpoint) + '"'}] {
+            padding-left: $value !important;
+            padding-right: $value !important;
+          }
+        } @else if $side == 'vertical' {
+          [cds-layout~=#{'"' + getPadAttributeString($side, $size, $breakpoint) + '"'}] {
+            padding-top: $value !important;
+            padding-bottom: $value !important;
+          }
+        } @else {
+          [cds-layout~=#{'"' + getPadAttributeString($side, $size, $breakpoint) + '"'}] {
+            padding-#{$side}: $value !important;
+          }
+        }
+      }
+    }
+  }
 }
 
-[cds-pad='md'],
-cds-layout[pad='md'] {
-  padding: $cds-token-layout-space-md !important;
+// padding all around
+
+@include cdsLayoutPadder();
+
+// Padding by axis
+
+@include cdsLayoutPadder('horizontal' 'vertical');
+
+// Padding by side
+
+@include cdsLayoutPadder('top' 'right' 'bottom' 'left');
+
+// responsive breakpoint – sm
+@media (min-width: $cds-token-layout-width-sm-static) {
+  @include cdsLayoutPadder(null, 'sm');
+  @include cdsLayoutPadder('horizontal' 'vertical', 'sm');
+  @include cdsLayoutPadder('top' 'right' 'bottom' 'left', 'sm');
 }
 
-[cds-pad='lg'],
-cds-layout[pad='lg'] {
-  padding: $cds-token-layout-space-lg !important;
+// responsive breakpoint – md
+@media (min-width: $cds-token-layout-width-md-static) {
+  @include cdsLayoutPadder(null, 'md');
+  @include cdsLayoutPadder('horizontal' 'vertical', 'md');
+  @include cdsLayoutPadder('top' 'right' 'bottom' 'left', 'md');
 }
 
-[cds-pad='xl'],
-cds-layout[pad='xl'] {
-  padding: $cds-token-layout-space-xl !important;
+// responsive breakpoint – lg
+@media (min-width: $cds-token-layout-width-lg-static) {
+  @include cdsLayoutPadder(null, 'lg');
+  @include cdsLayoutPadder('horizontal' 'vertical', 'lg');
+  @include cdsLayoutPadder('top' 'right' 'bottom' 'left', 'lg');
 }
 
-/* Padding by axis */
-
-[cds-pad^='[none'],
-cds-layout[pad^='[none'] {
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-}
-
-[cds-pad$='none]'],
-cds-layout[pad$='none]'] {
-  padding-left: 0 !important;
-  padding-right: 0 !important;
-}
-
-[cds-pad^='[xs'],
-cds-layout[pad^='[xs'] {
-  padding-top: $cds-token-layout-space-xs !important;
-  padding-bottom: $cds-token-layout-space-xs !important;
-}
-
-[cds-pad$='xs]'],
-cds-layout[pad$='xs]'] {
-  padding-left: $cds-token-layout-space-xs !important;
-  padding-right: $cds-token-layout-space-xs !important;
-}
-
-[cds-pad^='[sm'],
-cds-layout[pad^='[sm'] {
-  padding-top: $cds-token-layout-space-sm !important;
-  padding-bottom: $cds-token-layout-space-sm !important;
-}
-
-[cds-pad$='sm]'],
-cds-layout[pad$='sm]'] {
-  padding-left: $cds-token-layout-space-sm !important;
-  padding-right: $cds-token-layout-space-sm !important;
-}
-
-[cds-pad^='[md'],
-cds-layout[pad^='[md'] {
-  padding-top: $cds-token-layout-space-md !important;
-  padding-bottom: $cds-token-layout-space-md !important;
-}
-
-[cds-pad$='md]'],
-cds-layout[pad$='md]'] {
-  padding-left: $cds-token-layout-space-md !important;
-  padding-right: $cds-token-layout-space-md !important;
-}
-
-[cds-pad^='[lg'],
-cds-layout[pad^='[lg'] {
-  padding-top: $cds-token-layout-space-lg !important;
-  padding-bottom: $cds-token-layout-space-lg !important;
-}
-
-[cds-pad$='lg]'],
-cds-layout[pad$='lg]'] {
-  padding-left: $cds-token-layout-space-lg !important;
-  padding-right: $cds-token-layout-space-lg !important;
-}
-
-[cds-pad^='[xl'],
-cds-layout[pad^='[xl'] {
-  padding-top: $cds-token-layout-space-xl !important;
-  padding-bottom: $cds-token-layout-space-xl !important;
-}
-
-[cds-pad$='xl]'],
-cds-layout[pad$='xl]'] {
-  padding-left: $cds-token-layout-space-xl !important;
-  padding-right: $cds-token-layout-space-xl !important;
+// responsive breakpoint – xl
+@media (min-width: $cds-token-layout-width-xl-static) {
+  @include cdsLayoutPadder(null, 'xl');
+  @include cdsLayoutPadder('horizontal' 'vertical', 'xl');
+  @include cdsLayoutPadder('top' 'right' 'bottom' 'left', 'xl');
 }

--- a/src/clr-core/styles/layout/mixins/_mixins.scss
+++ b/src/clr-core/styles/layout/mixins/_mixins.scss
@@ -1,0 +1,103 @@
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+@function getSpacerAttributeString($prefix: 'pad', $side: null, $size: 'none', $breakpoint: null) {
+    $formattedSide: '';
+    $formattedBreakpoint: '';
+
+    @if $side {
+        $formattedSide: #{'-' + $side};
+    }
+
+    @if $breakpoint {
+        $formattedBreakpoint: #{'@' + $breakpoint};
+    }
+
+    @return #{$prefix + $formattedSide + '-' + $size + $formattedBreakpoint};
+}
+
+@function getPadAttributeString($side: null, $size: 'none', $breakpoint: null) {
+    @return getSpacerAttributeString('pad', $side, $size, $breakpoint);
+}
+
+@function getGapAttributeString($size: 'none', $breakpoint: null) {
+    @return getSpacerAttributeString('gap', null, $size, $breakpoint);
+}
+
+@function getLayoutSpacingToken($size: null) {
+    @if $size == 'xs' {
+        @return $cds-token-layout-space-xs;
+    } @else if $size == 'sm' {
+        @return $cds-token-layout-space-sm;
+    } @else if $size == 'md' {
+        @return $cds-token-layout-space-md;
+    } @else if $size == 'lg' {
+        @return $cds-token-layout-space-md;
+    } @else if $size == 'xl' {
+        @return $cds-token-layout-space-md;
+    } @else {
+        @return 0;
+    }
+}
+
+$tShirtSizes: 'none', 'xs', 'sm', 'md', 'lg', 'xl';
+
+@mixin cdsLayoutPadder($sides: null, $breakpoint: null) {
+    @each $size in $tShirtSizes {
+        $value: getLayoutSpacingToken($size);
+
+        @if $sides == null {
+            [cds-layout~=#{'"' + getPadAttributeString(null, $size, $breakpoint) + '"'}] {
+                padding: $value !important;
+            }
+        } @else {
+            @each $side in $sides {
+                @if $side == 'horizontal' {
+                    [cds-layout~=#{'"' + getPadAttributeString($side, $size, $breakpoint) + '"'}] {
+                        padding-left: $value !important;
+                        padding-right: $value !important;
+                    }
+                } @else if $side == 'vertical' {
+                    [cds-layout~=#{'"' + getPadAttributeString($side, $size, $breakpoint) + '"'}] {
+                        padding-top: $value !important;
+                        padding-bottom: $value !important;
+                    }
+                } @else {
+                    [cds-layout~=#{'"' + getPadAttributeString($side, $size, $breakpoint) + '"'}] {
+                        padding-#{$side}: $value !important;
+                    }
+                }
+            }
+        }
+    }
+}
+
+@mixin cdsLayoutHorizontalGapper($breakpoint: null) {
+    @each $size in $tShirtSizes {
+        @if $size != 'none' {
+            $value: getLayoutSpacingToken($size);
+    
+            &[cds-layout~=#{'"' + getGapAttributeString($size, $breakpoint) + '"'}] {
+                margin: calc(-1 * #{$value} 0 0 calc(-1 * #{$value}));
+                width: calc(100% + #{$value});
+
+                & > * {
+                    margin: #{$value} 0 0 #{$value};
+                }
+            }
+        }
+    }
+}
+
+@mixin cdsLayoutVerticalGapper($breakpoint: null) {
+    @each $size in $tShirtSizes {
+        @if $size != 'none' {
+            $value: getLayoutSpacingToken($size);
+    
+            &[cds-layout~=#{'"' + getGapAttributeString($size, $breakpoint) + '"'}] > * {
+                margin-bottom: #{$value};
+            }
+        }
+    }
+}

--- a/src/clr-core/styles/layout/mixins/_mixins.scss
+++ b/src/clr-core/styles/layout/mixins/_mixins.scss
@@ -33,9 +33,9 @@
     } @else if $size == 'md' {
         @return $cds-token-layout-space-md;
     } @else if $size == 'lg' {
-        @return $cds-token-layout-space-md;
+        @return $cds-token-layout-space-lg;
     } @else if $size == 'xl' {
-        @return $cds-token-layout-space-md;
+        @return $cds-token-layout-space-xl;
     } @else {
         @return 0;
     }

--- a/src/clr-core/styles/typography/_typography.scss
+++ b/src/clr-core/styles/typography/_typography.scss
@@ -23,19 +23,6 @@ html {
   );
 }
 
-[cds-body-text],
-[cds-text] {
-  $lh-gap: getLineHeightGap($cds-token-typography-body-line-height-static, $cds-token-typography-body-line-height);
-  @include LHE($lh-gap);
-
-  font-family: $cds-token-typography-font-family;
-  color: $cds-token-typography-body-color;
-  font-weight: $cds-token-typography-body-font-weight;
-  font-size: $cds-token-typography-body-font-size;
-  letter-spacing: $cds-token-typography-body-letter-spacing;
-  line-height: $cds-token-typography-body-line-height;
-}
-
 [cds-text] {
   display: block;
   width: 100%;
@@ -296,6 +283,21 @@ html {
   color: $cds-token-typography-subsection-color;
   line-height: $cds-token-typography-subsection-line-height;
   letter-spacing: $cds-token-typography-subsection-letter-spacing;
+}
+
+[cds-body-text],
+[cds-text*='body'] {
+  font-family: $cds-token-typography-font-family;
+  color: $cds-token-typography-body-color;
+  font-weight: $cds-token-typography-body-font-weight;
+  font-size: $cds-token-typography-body-font-size;
+  letter-spacing: $cds-token-typography-body-letter-spacing;
+  line-height: $cds-token-typography-body-line-height;
+}
+
+[cds-text*='body'] {
+  $lh-gap: getLineHeightGap($cds-token-typography-body-line-height-static, $cds-token-typography-body-line-height);
+  @include LHE($lh-gap);
 }
 
 [cds-text*='message'] {


### PR DESCRIPTION
• removed old cds-pad attr
• added pad-[side]-[size]@[breakpoint] values to cds-layout attr
• created SASS mixin and functions that may have utility beyond just padding
• frex, only need to allow for the "pad" portion to be a parameter to responsify almost any sizing

Signed-off-by: Scott Mathis <smathis@vmware.com>
