### PR TITLE
fix: adding lists to core

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,14 +95,15 @@
     "core:build:tokens": "node src/clr-core/styles/tokens/tokens-build.js",
     "core:build:sass": "npm-run-all 'core:build:sass:modules' -p 'core:build:sass:components' -s 'core:build:sass:min'",
     "core:build:sass:min": "npm-run-all -p core:build:sass:min:*",
-    "core:build:sass:watch": "npm-run-all 'core:build:sass' -p 'core:build:sass:components -- -w' 'core:build:sass:modules -- --watch' 'core:build:sass:min:global -- --watch' 'core:build:sass:min:layout -- --watch' 'core:build:sass:min:reset -- --watch' 'core:build:sass:min:tokens -- --watch' 'core:build:sass:min:typography -- --watch'",
+    "core:build:sass:watch": "npm-run-all 'core:build:sass' -p 'core:build:sass:components -- -w' 'core:build:sass:modules -- --watch' 'core:build:sass:min:global -- --watch' 'core:build:sass:min:layout -- --watch' 'core:build:sass:min:reset -- --watch' 'core:build:sass:min:tokens -- --watch' 'core:build:sass:min:typography -- --watch' 'core:build:sass:min:list -- --watch'",
     "core:build:sass:modules": "sass --no-source-map  src/clr-core/styles:dist/clr-core",
     "core:build:sass:components": "sass-render --q --suffix '.css.ts' -t ./src/clr-core/sass-template.js './src/clr-core/**/*element.scss'",
     "core:build:sass:min:global": "csso -i ./dist/clr-core/global.css -o ./dist/clr-core/global.min.css --no-restructure",
     "core:build:sass:min:layout": "csso -i ./dist/clr-core/module.layout.css -o ./dist/clr-core/module.layout.min.css --no-restructure",
     "core:build:sass:min:reset": "csso -i ./dist/clr-core/module.reset.css -o ./dist/clr-core/module.reset.min.css --no-restructure",
     "core:build:sass:min:tokens": "csso -i ./dist/clr-core/module.tokens.css -o ./dist/clr-core/module.tokens.min.css --no-restructure",
-    "core:build:sass:min:typography": "csso -i ./dist/clr-core/module.typography.css -o ./dist/clr-core/module.typography.min.css --no-restructure"
+    "core:build:sass:min:typography": "csso -i ./dist/clr-core/module.typography.css -o ./dist/clr-core/module.typography.min.css --no-restructure",
+    "core:build:sass:min:list": "csso -i ./dist/clr-core/module.list.css -o ./dist/clr-core/module.list.min.css --no-restructure"
   },
   "dependencies": {
     "@angular/animations": "9.0.2",

--- a/src/clr-core/.storybook/preview.js
+++ b/src/clr-core/.storybook/preview.js
@@ -2,6 +2,7 @@ import '!style-loader!css-loader!./../../../dist/clr-core/module.reset.min.css';
 import '!style-loader!css-loader!./../../../dist/clr-core/module.tokens.min.css';
 import '!style-loader!css-loader!./../../../dist/clr-core/module.layout.min.css';
 import '!style-loader!css-loader!./../../../dist/clr-core/module.typography.min.css';
+import '!style-loader!css-loader!./../../../dist/clr-core/module.list.min.css';
 import '!style-loader!css-loader!./../../../node_modules/@clr/city/css/bundles/default.min.css';
 import '!style-loader!css-loader!./public/demo.css';
 import { setCustomElements, addDecorator, addParameters } from '@storybook/web-components';

--- a/src/clr-core/styles/list/_list.scss
+++ b/src/clr-core/styles/list/_list.scss
@@ -10,15 +10,8 @@ $list-indent: $cds-token-layout-space-md;
 
     @if $styles != null {
         @each $style in $styles {
-            @if $style == $ul-default or $style == $ol-default {
-                #{$type}[cds-list],
-                #{$type}[cds-list='#{$style}'] {
-                    list-style-type: $style;
-                }
-            } @else {
-                #{$type}[cds-list='#{$style}'] {
-                    list-style-type: $style;
-                }
+            #{$type}[cds-list='#{$style}'] {
+                list-style-type: $style;
             }
         }
     }
@@ -32,15 +25,21 @@ $list-indent: $cds-token-layout-space-md;
     list-style-position: inside !important;
 }
 
-ul[cds-list]:not([cds-list='unstyled']),
 ol[cds-list] {
+    list-style-type: $cds-token-list-default-ordered-type;
+    list-style-position: outside;
+    padding-left: $list-indent;
+}
+
+ul[cds-list]:not([cds-list='unstyled']) {
+    list-style-type: $cds-token-list-default-unordered-type;
     list-style-position: outside;
     padding-left: $list-indent;
 }
 
 @include renderListStyles(ul, disc circle square);
 
-@include renderListStyles(ol, arabic-indic armenian bengali cjk-earthly-branch cjk-heavenly-stem cjk-ideographic decimal decimal-leading-zero devanagari ethiopic-halehame-am ethiopic-halehame-ti-er ethiopic-halehame-ti-et georgian gujarati gurmukhi hangul hangul-consonant hiragana hiragana-iroha kannada katakana katakana-iroha khmer korean-hangul-formal korean-hanja-formal korean-hanja-informal lao lower-alpha lower-greek lower-latin lower-roman malayalam mongolian myanmar oriya persian simp-chinese-formal simp-chinese-informal telugu thai upper-alpha upper-latin upper-roman urdu);
+@include renderListStyles(ol, decimal decimal-leading-zero lower-alpha lower-latin lower-roman upper-alpha upper-latin upper-roman);
 
 ul[cds-list='unstyled'] {
     @extend %kill-list-styles;
@@ -70,4 +69,10 @@ ol[cds-list] {
 ol[cds-list] > li > ol[cds-list] {
     margin-left: 0;
     padding-left: $list-indent;
+}
+
+ul[cds-layout~='horizontal'], ol[cds-layout~='horizontal'] {
+    li {
+        list-style-position: inside;
+    }
 }

--- a/src/clr-core/styles/list/_list.scss
+++ b/src/clr-core/styles/list/_list.scss
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+$list-indent: $cds-token-layout-space-md;
+
+@mixin renderListStyles($type: ul, $styles: null) {
+    $ul-default: disc;
+    $ol-default: decimal;
+
+    @if $styles != null {
+        @each $style in $styles {
+            @if $style == $ul-default or $style == $ol-default {
+                #{$type}[cds-list],
+                #{$type}[cds-list='#{$style}'] {
+                    list-style-type: $style;
+                }
+            } @else {
+                #{$type}[cds-list='#{$style}'] {
+                    list-style-type: $style;
+                }
+            }
+        }
+    }
+}
+
+%kill-list-styles {
+    padding-left: 0 !important;
+    margin-left: 0 !important;
+    // zero-width blank space added to help VoiceOver screen reader read a list-style-type none list
+    list-style: '\200B' !important;
+    list-style-position: inside !important;
+}
+
+ul[cds-list]:not([cds-list='unstyled']),
+ol[cds-list] {
+    list-style-position: outside;
+    padding-left: $list-indent;
+}
+
+@include renderListStyles(ul, disc circle square);
+
+@include renderListStyles(ol, arabic-indic armenian bengali cjk-earthly-branch cjk-heavenly-stem cjk-ideographic decimal decimal-leading-zero devanagari ethiopic-halehame-am ethiopic-halehame-ti-er ethiopic-halehame-ti-et georgian gujarati gurmukhi hangul hangul-consonant hiragana hiragana-iroha kannada katakana katakana-iroha khmer korean-hangul-formal korean-hanja-formal korean-hanja-informal lao lower-alpha lower-greek lower-latin lower-roman malayalam mongolian myanmar oriya persian simp-chinese-formal simp-chinese-informal telugu thai upper-alpha upper-latin upper-roman urdu);
+
+ul[cds-list='unstyled'] {
+    @extend %kill-list-styles;
+
+    & > li {
+        & > ul:not[cds-list='unstyled'],
+        ol {
+            margin-left: 0;
+            padding-left: $list-indent;
+        }
+
+        & > ul[cds-list='unstyled'] {
+            margin-left: 0;
+            padding-left: $list-indent !important;
+        }
+    }
+}
+
+ul:not([cds-list='unstyled']),
+ol[cds-list] {
+    & > li > ul[cds-list='unstyled'] {
+        margin-left: 0;
+        padding-left: $list-indent !important;
+    }
+}
+
+ol[cds-list] > li > ol[cds-list] {
+    margin-left: 0;
+    padding-left: $list-indent;
+}

--- a/src/clr-core/styles/list/_list.scss
+++ b/src/clr-core/styles/list/_list.scss
@@ -5,74 +5,78 @@
 $list-indent: $cds-token-layout-space-md;
 
 @mixin renderListStyles($type: ul, $styles: null) {
-    $ul-default: disc;
-    $ol-default: decimal;
+  $ul-default: disc;
+  $ol-default: decimal;
 
-    @if $styles != null {
-        @each $style in $styles {
-            #{$type}[cds-list='#{$style}'] {
-                list-style-type: $style;
-            }
-        }
+  @if $styles != null {
+    @each $style in $styles {
+      #{$type}[cds-list='#{$style}'] {
+        list-style-type: $style;
+      }
     }
+  }
 }
 
 %kill-list-styles {
-    padding-left: 0 !important;
-    margin-left: 0 !important;
-    // zero-width blank space added to help VoiceOver screen reader read a list-style-type none list
-    list-style: '\200B' !important;
-    list-style-position: inside !important;
+  padding-left: 0 !important;
+  margin-left: 0 !important;
+  // zero-width blank space added to help VoiceOver screen reader read a list-style-type none list
+  list-style: '\200B' !important;
+  list-style-position: inside !important;
 }
 
 ol[cds-list] {
-    list-style-type: $cds-token-list-default-ordered-type;
-    list-style-position: outside;
-    padding-left: $list-indent;
+  list-style-type: $cds-token-list-default-ordered-type;
+  list-style-position: outside;
+  padding-left: $list-indent;
 }
 
 ul[cds-list]:not([cds-list='unstyled']) {
-    list-style-type: $cds-token-list-default-unordered-type;
-    list-style-position: outside;
-    padding-left: $list-indent;
+  list-style-type: $cds-token-list-default-unordered-type;
+  list-style-position: outside;
+  padding-left: $list-indent;
 }
 
 @include renderListStyles(ul, disc circle square);
 
-@include renderListStyles(ol, decimal decimal-leading-zero lower-alpha lower-latin lower-roman upper-alpha upper-latin upper-roman);
+@include renderListStyles(
+  ol,
+  decimal decimal-leading-zero lower-alpha lower-latin lower-roman upper-alpha upper-latin upper-roman
+);
 
 ul[cds-list='unstyled'] {
-    @extend %kill-list-styles;
+  @extend %kill-list-styles;
 
-    & > li {
-        & > ul:not[cds-list='unstyled'],
-        ol {
-            margin-left: 0;
-            padding-left: $list-indent;
-        }
-
-        & > ul[cds-list='unstyled'] {
-            margin-left: 0;
-            padding-left: $list-indent !important;
-        }
+  & > li {
+    & > ul:not[cds-list='unstyled'],
+    ol {
+      margin-left: 0;
+      padding-left: $list-indent;
     }
+
+    & > ul[cds-list='unstyled'] {
+      margin-left: 0;
+      padding-left: $list-indent !important;
+    }
+  }
 }
 
 ul:not([cds-list='unstyled']),
 ol[cds-list] {
-    & > li > ul[cds-list='unstyled'] {
-        margin-left: 0;
-        padding-left: $list-indent !important;
-    }
+  & > li > ul[cds-list='unstyled'] {
+    margin-left: 0;
+    padding-left: $list-indent !important;
+  }
 }
 
 ol[cds-list] > li > ol[cds-list] {
-    margin-left: 0;
-    padding-left: $list-indent;
+  margin-left: 0;
+  padding-left: $list-indent;
 }
 
-ul[cds-layout~='horizontal'], ol[cds-layout~='horizontal'] {
-    li {
-        list-style-position: inside;
-    }
+ul[cds-layout~='horizontal'],
+ol[cds-layout~='horizontal'] {
+  li {
+    list-style-position: inside;
+  }
 }

--- a/src/clr-core/styles/list/list.stories.ts
+++ b/src/clr-core/styles/list/list.stories.ts
@@ -25,50 +25,14 @@ const unorderedListOptions: object = {
 
 const orderedListOptions: object = { 
     'none (default decimal)': '', 
-    'arabic-indic': 'arabic-indic',
-    'armenian': 'armenian',
-    'bengali': 'bengali',
-    'cjk-earthly-branch': 'cjk-earthly-branch',
-    'cjk-heavenly-stem': 'cjk-heavenly-stem',
-    'cjk-ideographic': 'cjk-ideographic',
     'decimal': 'decimal',
     'decimal-leading-zero': 'decimal-leading-zero',
-    'devanagari': 'devanagari',
-    'ethiopic-halehame-am': 'ethiopic-halehame-am',
-    'ethiopic-halehame-ti-er': 'ethiopic-halehame-ti-er',
-    'ethiopic-halehame-ti-et': 'ethiopic-halehame-ti-et',
-    'georgian': 'georgian',
-    'gujarati': 'gujarati',
-    'gurmukhi': 'gurmukhi',
-    'hangul': 'hangul',
-    'hangul-consonant': 'hangul-consonant',
-    'hiragana': 'hiragana',
-    'hiragana-iroha': 'hiragana-iroha',
-    'kannada': 'kannada',
-    'katakana': 'katakana',
-    'katakana-iroha': 'katakana-iroha',
-    'khmer': 'khmer',
-    'korean-hangul-formal': 'korean-hangul-formal',
-    'korean-hanja-formal': 'korean-hanja-formal',
-    'korean-hanja-informal': 'korean-hanja-informal',
-    'lao': 'lao',
     'lower-alpha': 'lower-alpha',
-    'lower-greek': 'lower-greek',
     'lower-latin': 'lower-latin',
     'lower-roman': 'lower-roman',
-    'malayalam': 'malayalam',
-    'mongolian': 'mongolian',
-    'myanmar': 'myanmar',
-    'oriya': 'oriya',
-    'persian': 'persian',
-    'simp-chinese-formal': 'simp-chinese-formal',
-    'simp-chinese-informal': 'simp-chinese-informal',
-    'telugu': 'telugu',
-    'thai': 'thai',
     'upper-alpha': 'upper-alpha',
     'upper-latin': 'upper-latin',
-    'upper-roman': 'upper-roman',
-    'urdu': 'urdu'
+    'upper-roman': 'upper-roman'
 };
 
 export const API = () => {
@@ -386,6 +350,59 @@ export const API = () => {
             </ul>
         </div>
       </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+            <h2 cds-text="h2">Custom/Regional Ordered Lists</h2>
+            <ol cds-list class="mongolian">
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+            </ol>
+        </div>
+      </cds-card>
+
+      <style>
+        ol.mongolian {
+          list-style-type: 'mongolian';
+        }
+      </style>
+
+      <cds-card>
+        <div cds-layout="vertical gap-md">
+            <h2 cds-text="h2">Lists + Layouts</h2>
+            <h3 cds-text="section">Vertical</h3>
+            <ul cds-list cds-layout="vertical gap-md">
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+            </ul>
+            <h3 cds-text="section">Horizontal</h3>
+            <ol cds-list="upper-roman" cds-layout="horizontal gap-sm">
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+            </ol>
+        </div>
+      </cds-card>
+
+      <style>
+        ol.mongolian {
+          list-style-type: mongolian;
+        }
+      </style>
 
     </div>
   `;

--- a/src/clr-core/styles/list/list.stories.ts
+++ b/src/clr-core/styles/list/list.stories.ts
@@ -16,46 +16,31 @@ export default {
   },
 };
 
-const unorderedListOptions: object = { 
-    'none (default disc)': '', 
-    'disc': 'disc',
-    'circle': 'circle',
-    'square': 'square'
+const unorderedListOptions: object = {
+  'none (default disc)': '',
+  disc: 'disc',
+  circle: 'circle',
+  square: 'square',
 };
 
-const orderedListOptions: object = { 
-    'none (default decimal)': '', 
-    'decimal': 'decimal',
-    'decimal-leading-zero': 'decimal-leading-zero',
-    'lower-alpha': 'lower-alpha',
-    'lower-latin': 'lower-latin',
-    'lower-roman': 'lower-roman',
-    'upper-alpha': 'upper-alpha',
-    'upper-latin': 'upper-latin',
-    'upper-roman': 'upper-roman'
+const orderedListOptions: object = {
+  'none (default decimal)': '',
+  decimal: 'decimal',
+  'decimal-leading-zero': 'decimal-leading-zero',
+  'lower-alpha': 'lower-alpha',
+  'lower-latin': 'lower-latin',
+  'lower-roman': 'lower-roman',
+  'upper-alpha': 'upper-alpha',
+  'upper-latin': 'upper-latin',
+  'upper-roman': 'upper-roman',
 };
 
 export const API = () => {
-  const orderedListStyle = select(
-    'Ordered List Style',
-    orderedListOptions,
-    undefined,
-    propertiesGroup
-  );
+  const orderedListStyle = select('Ordered List Style', orderedListOptions, undefined, propertiesGroup);
 
-  const orderedListChildStyle = select(
-    'Ordered List Style (Child)',
-    orderedListOptions,
-    undefined,
-    propertiesGroup
-  );
+  const orderedListChildStyle = select('Ordered List Style (Child)', orderedListOptions, undefined, propertiesGroup);
 
-  const unorderedListStyle = select(
-    'Unordered List Style',
-    unorderedListOptions,
-    undefined,
-    propertiesGroup
-  );
+  const unorderedListStyle = select('Unordered List Style', unorderedListOptions, undefined, propertiesGroup);
 
   const unorderedListChildStyle = select(
     'Unordered List Style (Child)',

--- a/src/clr-core/styles/list/list.stories.ts
+++ b/src/clr-core/styles/list/list.stories.ts
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { propertiesGroup } from '@clr/core/common';
+import { select } from '@storybook/addon-knobs';
+import { html } from 'lit-html';
+
+export default {
+  title: 'Experimental/List',
+  parameters: {
+    options: { showPanel: true },
+    a11y: { disable: true },
+  },
+};
+
+const unorderedListOptions: object = { 
+    'none (default disc)': '', 
+    'disc': 'disc',
+    'circle': 'circle',
+    'square': 'square'
+};
+
+const orderedListOptions: object = { 
+    'none (default decimal)': '', 
+    'arabic-indic': 'arabic-indic',
+    'armenian': 'armenian',
+    'bengali': 'bengali',
+    'cjk-earthly-branch': 'cjk-earthly-branch',
+    'cjk-heavenly-stem': 'cjk-heavenly-stem',
+    'cjk-ideographic': 'cjk-ideographic',
+    'decimal': 'decimal',
+    'decimal-leading-zero': 'decimal-leading-zero',
+    'devanagari': 'devanagari',
+    'ethiopic-halehame-am': 'ethiopic-halehame-am',
+    'ethiopic-halehame-ti-er': 'ethiopic-halehame-ti-er',
+    'ethiopic-halehame-ti-et': 'ethiopic-halehame-ti-et',
+    'georgian': 'georgian',
+    'gujarati': 'gujarati',
+    'gurmukhi': 'gurmukhi',
+    'hangul': 'hangul',
+    'hangul-consonant': 'hangul-consonant',
+    'hiragana': 'hiragana',
+    'hiragana-iroha': 'hiragana-iroha',
+    'kannada': 'kannada',
+    'katakana': 'katakana',
+    'katakana-iroha': 'katakana-iroha',
+    'khmer': 'khmer',
+    'korean-hangul-formal': 'korean-hangul-formal',
+    'korean-hanja-formal': 'korean-hanja-formal',
+    'korean-hanja-informal': 'korean-hanja-informal',
+    'lao': 'lao',
+    'lower-alpha': 'lower-alpha',
+    'lower-greek': 'lower-greek',
+    'lower-latin': 'lower-latin',
+    'lower-roman': 'lower-roman',
+    'malayalam': 'malayalam',
+    'mongolian': 'mongolian',
+    'myanmar': 'myanmar',
+    'oriya': 'oriya',
+    'persian': 'persian',
+    'simp-chinese-formal': 'simp-chinese-formal',
+    'simp-chinese-informal': 'simp-chinese-informal',
+    'telugu': 'telugu',
+    'thai': 'thai',
+    'upper-alpha': 'upper-alpha',
+    'upper-latin': 'upper-latin',
+    'upper-roman': 'upper-roman',
+    'urdu': 'urdu'
+};
+
+export const API = () => {
+  const orderedListStyle = select(
+    'Ordered List Style',
+    orderedListOptions,
+    undefined,
+    propertiesGroup
+  );
+
+  const orderedListChildStyle = select(
+    'Ordered List Style (Child)',
+    orderedListOptions,
+    undefined,
+    propertiesGroup
+  );
+
+  const unorderedListStyle = select(
+    'Unordered List Style',
+    unorderedListOptions,
+    undefined,
+    propertiesGroup
+  );
+
+  const unorderedListChildStyle = select(
+    'Unordered List Style (Child)',
+    unorderedListOptions,
+    undefined,
+    propertiesGroup
+  );
+
+  return html`
+    <div cds-layout="vertical gap-md" cds-body-text>
+      <h1 cds-text="h1">Lists (Experimental)</h1>
+
+      <div cds-layout="vertical gap-sm">
+        <p>
+            Lists in Clarity Core come in three varieties – ordered, unordered, and unstyled. 
+            Any "compact" style variations for list display is now handled through Clarity Core layouts.
+        </p>
+      </div>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+          <h2 cds-text="h2">Unstyled List</h2>
+          <ul cds-list="unstyled">
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+          </ul>
+        </div>
+      </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+          <h2 cds-text="h2">Ordered List</h2>
+          <ol cds-list=${orderedListStyle}>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+          </ol>
+        </div>
+      </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+          <h2 cds-text="h2">Unordered List</h2>
+          <ul cds-list=${unorderedListStyle}>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+              <li>The five boxing wizards jump quickly</li>
+          </ul>
+        </div>
+      </cds-card>
+
+      <h2 cds-text="h2">Mixed and Nested Lists</h2>
+
+      <p cds-text="p1">
+          Lists can be nested and the varieties can be mixed within nested groupings.
+      </p>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+          <h2 cds-text="h2">Nested Ordered Lists</h2>
+          <ol cds-list=${orderedListStyle}>
+              <li>The quick brown fox jumps over the lazy dog</li>
+              <li>The quick brown fox jumps over the lazy dog</li>
+              <li>The quick brown fox jumps over the lazy dog</li>
+              <li>The quick brown fox jumps over the lazy dog</li>
+              <li>The quick brown fox jumps over the lazy dog
+                <ol cds-list=${orderedListChildStyle}>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                </ol>
+              </li>
+              <li>The quick brown fox jumps over the lazy dog</li>
+              <li>The quick brown fox jumps over the lazy dog</li>
+          </ol>
+        </div>
+      </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+          <h2 cds-text="h2">Nested Ordered + Unstyled Lists</h2>
+          <ol cds-list=${orderedListStyle}>
+              <li>The quick brown fox jumps over the lazy dog</li>
+              <li>The quick brown fox jumps over the lazy dog</li>
+              <li>The quick brown fox jumps over the lazy dog</li>
+              <li>The quick brown fox jumps over the lazy dog</li>
+              <li>The quick brown fox jumps over the lazy dog
+                <ul cds-list="unstyled">
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                    <li>The five boxing wizards jump quickly</li>
+                </ul>
+              </li>
+              <li>The quick brown fox jumps over the lazy dog</li>
+              <li>The quick brown fox jumps over the lazy dog</li>
+          </ol>
+        </div>
+      </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+            <h2 cds-text="h2">Nested Ordered + Unordered Lists</h2>
+            <ol cds-list=${orderedListStyle}>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog
+                    <ul cds-list=${unorderedListChildStyle}>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                    </ul>
+                </li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+            </ol>
+        </div>
+      </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+            <h2 cds-text="h2">Nested Unordered Lists</h2>
+            <ul cds-list=${unorderedListStyle}>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog
+                    <ul cds-list=${unorderedListChildStyle}>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                    </ul>
+                </li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+            </ul>
+        </div>
+      </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+            <h2 cds-text="h2">Nested Unordered + Ordered Lists</h2>
+            <ul cds-list=${unorderedListStyle}>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog
+                    <ol cds-list=${orderedListChildStyle}>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                    </ol>
+                </li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+            </ul>
+        </div>
+      </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+            <h2 cds-text="h2">Nested Unordered + Unstyled Lists</h2>
+            <ul cds-list=${unorderedListStyle}>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog
+                    <ul cds-list="unstyled">
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                    </ul>
+                </li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+            </ul>
+        </div>
+      </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+            <h2 cds-text="h2">Nested Unstyled Lists</h2>
+            <ul cds-list="unstyled">
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog
+                    <ul cds-list="unstyled">
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                    </ul>
+                </li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+            </ul>
+        </div>
+      </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+            <h2 cds-text="h2">Nested Unstyled + Ordered Lists</h2>
+            <ul cds-list="unstyled">
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog
+                    <ol cds-list=${orderedListChildStyle}>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                    </ol>
+                </li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+            </ul>
+        </div>
+      </cds-card>
+
+      <cds-card>
+        <div cds-layout="vertical gap-sm">
+            <h2 cds-text="h2">Nested Unstyled + Unordered Lists</h2>
+            <ul cds-list="unstyled">
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog
+                    <ul cds-list=${unorderedListChildStyle}>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                        <li>The five boxing wizards jump quickly</li>
+                    </ul>
+                </li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+                <li>The quick brown fox jumps over the lazy dog</li>
+            </ul>
+        </div>
+      </cds-card>
+
+    </div>
+  `;
+};

--- a/src/clr-core/styles/module.list.scss
+++ b/src/clr-core/styles/module.list.scss
@@ -3,5 +3,5 @@
 // The full license information can be found in LICENSE in the root directory of this project.
 
 /*! Experimental API - Do not use in production! */
-@import './tokens/index.generated';
+@import './tokens/generated/index';
 @import './list/list';

--- a/src/clr-core/styles/module.list.scss
+++ b/src/clr-core/styles/module.list.scss
@@ -1,0 +1,7 @@
+// Copyright (c) 2016-2020 VMware, Inc. All Rights Reserved.
+// This software is released under MIT license.
+// The full license information can be found in LICENSE in the root directory of this project.
+
+/*! Experimental API - Do not use in production! */
+@import './tokens/index.generated';
+@import './list/list';

--- a/src/clr-core/styles/tokens/tokens.yml
+++ b/src/clr-core/styles/tokens/tokens.yml
@@ -688,3 +688,13 @@ props:
    value: 400
    type: 'number'
    category: 'typography'
+
+  # lists
+  default-unordered-type:
+    value: 'disc'
+    type: 'string'
+    category: 'list'
+  default-ordered-type:
+    value: 'decimal'
+    type: 'string'
+    category: 'list'

--- a/src/clr-core/test-bundles/bundlesize.json
+++ b/src/clr-core/test-bundles/bundlesize.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "./dist/clr-core/module.layout.min.css",
-      "maxSize": "5 kB"
+      "maxSize": "6 kB"
     },
     {
       "path": "./dist/clr-core/module.reset.min.css",
@@ -21,8 +21,12 @@
       "maxSize": "3 kB"
     },
     {
+      "path": "./dist/clr-core/module.list.min.css",
+      "maxSize": "1 kB"
+    },
+    {
       "path": "./dist/test-bundles/webpack.bundle.js",
-      "maxSize": "22 kB"
+      "maxSize": "23 kB"
     }
   ]
 }


### PR DESCRIPTION
• added global css for ol and ul elements
• created SASS module for lists
• fixed minor issue with vertical layout attr selector
• encapsulated all list styles within `cds-list` attr
• created styles for ordered, unordered, and unsettled lists
• created styles to handle nested lists
• created ordered attr values for ~50 regions listed as supported on MDN
• made them different values b/c we can't update a CSS var on a non-root scope in IE #ThanksAgainIE
• users may also want more granular typings that would not be feasible with global CSS vars
• once we drop IE support (sometime in 2100 AD?) we can refactor these styles to use a single CSS var
• the list of regions will still be useful tho

Signed-off-by: Scott Mathis <smathis@vmware.com>
